### PR TITLE
Enable user to store additional extensions on host folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ The installer will ask a series of questions, install MediaWiki to the database,
 
 ## Running MediaWiki
 
-Once you have LocalSettings.php, you can start MediaWiki and run it normally by mounting the LocalSettings to the container. You will also have to provide an image folder so that you can upload to your Wiki as well.
+Once you have LocalSettings.php, you can start MediaWiki and run it normally by mounting the LocalSettings to the container. You will also have to provide an image folder and extension folder so that you can upload to your Wiki and add additional extension as well.
 
-	sudo docker run -v <path to LocalSettings.php>:/usr/share/nginx/html/LocalSettings.php:ro -v <path to images>:/usr/share/nginx/html/images --link mysql:db -p 80:80 -p 443:443 -d simplyintricate/mediawiki
+	sudo docker run -v <path to LocalSettings.php>:/usr/share/nginx/html/LocalSettings.php:ro -v <path to images>:/usr/share/nginx/html/images -v <path to extensions>:/tmp/extensions --link mysql:db -p 80:80 -p 443:443 -d simplyintricate/mediawiki
 
 To help maintain immutability of the container, you may extend this image to include your LocalSettings.php into your own version of MediaWiki. Here is a sample Dockerfile for that
 

--- a/start.sh
+++ b/start.sh
@@ -3,6 +3,7 @@
 # Chown volumes so that nginx can read/write
 chown www-data:www-data /usr/share/nginx/html/images
 chown www-data:www-data /usr/share/nginx/html/LocalSettings.php
+cp /tmp/extensions /usr/share/nginx/html/extensions
 
 service php5-fpm start;
 nginx -g "daemon off;"

--- a/start.sh
+++ b/start.sh
@@ -3,7 +3,8 @@
 # Chown volumes so that nginx can read/write
 chown www-data:www-data /usr/share/nginx/html/images
 chown www-data:www-data /usr/share/nginx/html/LocalSettings.php
-cp -r /tmp/extensions/ /usr/share/nginx/html/extensions/
+chown -R www-data:www-data /tmp/extensions/
+cp -r /tmp/extensions/* /usr/share/nginx/html/extensions/
 
 service php5-fpm start;
 nginx -g "daemon off;"

--- a/start.sh
+++ b/start.sh
@@ -3,7 +3,7 @@
 # Chown volumes so that nginx can read/write
 chown www-data:www-data /usr/share/nginx/html/images
 chown www-data:www-data /usr/share/nginx/html/LocalSettings.php
-cp /tmp/extensions /usr/share/nginx/html/extensions
+cp -r /tmp/extensions/ /usr/share/nginx/html/extensions/
 
 service php5-fpm start;
 nginx -g "daemon off;"


### PR DESCRIPTION
If user want to add new extensions, they simply need to put it in host folder. On start.sh, those extensions will be merged to the existing extensions in the container.
